### PR TITLE
検索のオプションの追加

### DIFF
--- a/cruds/works/__init__.py
+++ b/cruds/works/__init__.py
@@ -100,6 +100,10 @@ def get_works_by_limit(
 
     works_orm = (
         db.query(models.Work)
+        .join(models.User,models.Work.user_id==models.User.id)
+        .join(models.Tagging,models.Work.id==models.Tagging.work_id)
+        .join(models.Tag,models.Tagging.tag_id==models.Tag.id)
+        .group_by(models.Work.id)
         .order_by(desc(models.Work.created_at))
         .filter(models.Work.visibility != models.Visibility.draft)
     )
@@ -117,7 +121,7 @@ def get_works_by_limit(
         )
     if tag_names:
         tag_name_list = tag_names.split(",")
-        works_orm = works_orm.filter(models.Tag.name.in_(tag_name_list)).filter(models.Tagging.tag_id==models.Tag.id).filter(
+        works_orm = works_orm.filter(models.Tag.name.in_(tag_name_list)).filter(
             models.Tagging.work_id == models.Work.id
         )
         works_orm = works_orm.group_by(models.Work.id).having(
@@ -364,7 +368,7 @@ def get_works_by_user_id(
         works_orm = works_orm.group_by(models.Work.id).having(
             func.count(models.Work.id) == len(tag_list)
         )
-    
+
     if user is None:
         works_orm = works_orm.filter(models.Work.visibility == models.Visibility.public)
     elif user.id != user_id:
@@ -372,7 +376,7 @@ def get_works_by_user_id(
 
     if visibility is not None:
         works_orm = works_orm.filter(models.Work.visibility == visibility)
-    
+
     works_total_count = works_orm.count()
 
     if oldest_work_id:

--- a/cruds/works/__init__.py
+++ b/cruds/works/__init__.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 import markdown
 from fastapi import HTTPException
-from sqlalchemy import desc, func
+from sqlalchemy import desc, func, or_
 from sqlalchemy.orm.session import Session
 
 from cruds.assets import delete_asset_by_id
@@ -91,6 +91,7 @@ def get_works_by_limit(
     tag_names: str,
     tag_ids: str,
     user: Optional[User],
+    search_word:str,
 ) -> ResWorks:
     if tag_names != None and tag_ids != None:
         raise HTTPException(
@@ -102,6 +103,10 @@ def get_works_by_limit(
         .order_by(desc(models.Work.created_at))
         .filter(models.Work.visibility != models.Visibility.draft)
     )
+    if search_word:
+        works_orm = works_orm.filter(or_(models.User.name.ilike(f"%{search_word}%"),or_(models.Tag.name.ilike(f"%{search_word}%"),models.Work.title.ilike(f"%{search_word}%"))))
+
+
     if tag_ids:
         tag_id_list = tag_ids.split(",")
         works_orm = works_orm.filter(models.Tagging.tag_id.in_(tag_id_list)).filter(

--- a/cruds/works/__init__.py
+++ b/cruds/works/__init__.py
@@ -92,6 +92,11 @@ def get_works_by_limit(
     tag_ids: str,
     user: Optional[User],
 ) -> ResWorks:
+    if tag_names != None and tag_ids != None:
+        raise HTTPException(
+            status_code=422, detail="tag name and ID cannot be specified at the same time."
+        )
+
     works_orm = (
         db.query(models.Work)
         .order_by(desc(models.Work.created_at))
@@ -131,7 +136,6 @@ def get_works_by_limit(
         works_orm = works_orm.filter(models.Work.visibility == models.Visibility.public)
     elif visibility is not None:
         works_orm = works_orm.filter(models.Work.visibility == visibility)
-
     works_total_count = works_orm.count()
     works_orm = works_orm.limit(limit).all()
 

--- a/cruds/works/__init__.py
+++ b/cruds/works/__init__.py
@@ -108,7 +108,7 @@ def get_works_by_limit(
         .filter(models.Work.visibility != models.Visibility.draft)
     )
     if search_word:
-        works_orm = works_orm.filter(or_(models.User.name.ilike(f"%{search_word}%"),or_(models.Tag.name.ilike(f"%{search_word}%"),models.Work.title.ilike(f"%{search_word}%"))))
+        works_orm = works_orm.filter(or_(models.User.name.ilike(f"%{search_word}%"),models.Tag.name.ilike(f"%{search_word}%"),models.Work.title.ilike(f"%{search_word}%")))
 
 
     if tag_ids:

--- a/routers/works/__init__.py
+++ b/routers/works/__init__.py
@@ -58,9 +58,10 @@ async def get_works(
     tag_ids:str = None,
     db: Session = Depends(get_db),
     user: User = Depends(GetCurrentUser(auto_error=False)),
+    search_word:str= None
 ):
     works = get_works_by_limit(
-        db, limit, visibility, oldest_work_id, newest_work_id,tag_names, tag_ids, user
+        db, limit, visibility, oldest_work_id, newest_work_id,tag_names, tag_ids, user,search_word
     )
     return works
 

--- a/routers/works/__init__.py
+++ b/routers/works/__init__.py
@@ -1,20 +1,17 @@
 import os
-from schemas.common import DeleteStatus
-from schemas.work import PostWork, Work, ResWorks
-from schemas.user import User
+from typing import List
+
 from fastapi import APIRouter
-from db import get_db, models
 from fastapi.params import Depends
 from sqlalchemy.orm import Session
+
 from cruds.users.auth import GetCurrentUser
-from cruds.works import (
-    delete_work_by_id,
-    get_work_by_id,
-    get_works_by_limit,
-    replace_work,
-    set_work,
-)
-from typing import List
+from cruds.works import (delete_work_by_id, get_work_by_id, get_works_by_limit,
+                         replace_work, set_work)
+from db import get_db, models
+from schemas.common import DeleteStatus
+from schemas.user import User
+from schemas.work import PostWork, ResWorks, Work
 from utils.discord import notice_discord
 
 FRONTEND_HOST_URL = os.environ.get("FRONTEND_HOST_URL")
@@ -57,12 +54,13 @@ async def get_works(
     visibility: models.Visibility = None,
     oldest_work_id: str = None,
     newest_work_id: str = None,
-    tags: str = None,
+    tag_names: str = None,
+    tag_ids:str = None,
     db: Session = Depends(get_db),
     user: User = Depends(GetCurrentUser(auto_error=False)),
 ):
     works = get_works_by_limit(
-        db, limit, visibility, oldest_work_id, newest_work_id, tags, user
+        db, limit, visibility, oldest_work_id, newest_work_id,tag_names, tag_ids, user
     )
     return works
 
@@ -107,3 +105,5 @@ async def delete_work(
     user_id = None if user is None else user.id
     result = delete_work_by_id(db, work_id, user_id)
     return result
+
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 import os
-import boto3
 import time
-from logging import INFO, ERROR, getLogger
+from logging import ERROR, INFO, getLogger
+
+import boto3
 
 S3_BUCKET = os.environ.get("S3_BUCKET")
 S3_DIR = "test_assets"
@@ -21,15 +22,15 @@ logger = getLogger("Session Finish")
 
 def pytest_sessionfinish():
     response = wasabi.list_objects_v2(Bucket=S3_BUCKET, Prefix=f"{S3_DIR}/image/")
-    for obj in response["Contents"]:
-        time.sleep(0.1)
-        response = wasabi.delete_object(
-            Bucket=S3_BUCKET, Key=obj["Key"].replace("/origin.png", "")
-        )
+    # for obj in response["Contents"]:
+    #     time.sleep(0.1)
+    #     response = wasabi.delete_object(
+    #         Bucket=S3_BUCKET, Key=obj["Key"].replace("/origin.png", "")
+    #     )
 
-        if response["ResponseMetadata"]["HTTPStatusCode"] == 204:
-            logger.info(obj["Key"].replace("/origin.png", ""))
-            logger.info(response)
-        else:
-            logger.error(obj["Key"].replace("/origin.png", ""))
-            logger.error(response)
+    #     if response["ResponseMetadata"]["HTTPStatusCode"] == 204:
+    #         logger.info(obj["Key"].replace("/origin.png", ""))
+    #         logger.info(response)
+    #     else:
+    #         logger.error(obj["Key"].replace("/origin.png", ""))
+    #         logger.error(response)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,15 +22,15 @@ logger = getLogger("Session Finish")
 
 def pytest_sessionfinish():
     response = wasabi.list_objects_v2(Bucket=S3_BUCKET, Prefix=f"{S3_DIR}/image/")
-    # for obj in response["Contents"]:
-    #     time.sleep(0.1)
-    #     response = wasabi.delete_object(
-    #         Bucket=S3_BUCKET, Key=obj["Key"].replace("/origin.png", "")
-    #     )
+    for obj in response["Contents"]:
+        time.sleep(0.1)
+        response = wasabi.delete_object(
+            Bucket=S3_BUCKET, Key=obj["Key"].replace("/origin.png", "")
+        )
 
-    #     if response["ResponseMetadata"]["HTTPStatusCode"] == 204:
-    #         logger.info(obj["Key"].replace("/origin.png", ""))
-    #         logger.info(response)
-    #     else:
-    #         logger.error(obj["Key"].replace("/origin.png", ""))
-    #         logger.error(response)
+        if response["ResponseMetadata"]["HTTPStatusCode"] == 204:
+            logger.info(obj["Key"].replace("/origin.png", ""))
+            logger.info(response)
+        else:
+            logger.error(obj["Key"].replace("/origin.png", ""))
+            logger.error(response)

--- a/tests/test_work.py
+++ b/tests/test_work.py
@@ -657,4 +657,81 @@ class TestWork:
         res_json = res.json()
         assert len(res_json["works"]) == 0
 
+    def test_search_works_by_tag_ids(
+            use_test_db_fixture,work_factory_for_test
+    ):
+        test_tag1 = tag_factory_for_test(name="testtag1", color="#ff3030")
+        test_tag2 = tag_factory_for_test(name="testtag2", color="#30ff30")
+        test_tag3 = tag_factory_for_test(name="testtag3", color="#3030ff")
+        test_tag4 = tag_factory_for_test(name="testtag4", color="#44e099")
+        test_tag5 = tag_factory_for_test(name="testtag5", color="#30dda0")
 
+        work1 = work_factory_for_test(
+            title="testwork1",
+            visibility=Visibility.public,
+            tags_id=[test_tag1.id, test_tag2.id, test_tag5.id],
+        )
+        work2 = work_factory_for_test(
+            title="testwork2",
+            visibility=Visibility.public,
+            tags_id=[test_tag2.id, test_tag3.id, test_tag5.id],
+        )
+        work3 = work_factory_for_test(
+            title="testwork3",
+            visibility=Visibility.private,
+            tags_id=[test_tag1.id, test_tag4.id, test_tag5.id],
+        )
+
+        res = client.get(f"/api/v1/works?tag_ids={test_tag1.id},{test_tag2.id}")
+
+        assert res.status_code == 200
+        res_json = res.json()
+        assert len(res_json["works"]) == 1
+        assert res_json["works"][0].get("title") == work1.title.title
+
+        res = client.get(f"/api/v1/works?tag_ids={test_tag5.id}")
+
+        assert res.status_code == 200
+        res_json = res.json()
+        assert len(res_json["works"]) == 3
+        for work in res_json["works"]:
+            assert work.get("title") in [work1.title,work2.title,work3.title]
+    def test_search_works_by_tag_ids(
+            use_test_db_fixture,work_factory_for_test
+    ):
+        test_tag1 = tag_factory_for_test(name="testtag1", color="#ff3030")
+        test_tag2 = tag_factory_for_test(name="testtag2", color="#30ff30")
+        test_tag3 = tag_factory_for_test(name="testtag3", color="#3030ff")
+        test_tag4 = tag_factory_for_test(name="testtag4", color="#44e099")
+        test_tag5 = tag_factory_for_test(name="testtag5", color="#30dda0")
+
+        work1 = work_factory_for_test(
+            title="testwork1",
+            visibility=Visibility.public,
+            tags_id=[test_tag1.id, test_tag2.id, test_tag5.id],
+        )
+        work2 = work_factory_for_test(
+            title="testwork2",
+            visibility=Visibility.public,
+            tags_id=[test_tag2.id, test_tag3.id, test_tag5.id],
+        )
+        work3 = work_factory_for_test(
+            title="testwork3",
+            visibility=Visibility.private,
+            tags_id=[test_tag1.id, test_tag4.id, test_tag5.id],
+        )
+
+        res = client.get(f"/api/v1/works?tag_names={test_tag1.name},{test_tag2.name}")
+
+        assert res.status_code == 200
+        res_json = res.json()
+        assert len(res_json["works"]) == 1
+        assert res_json["works"][0].get("title") == work1.title.title
+
+        res = client.get(f"/api/v1/works?tag_ids={test_tag5.name}")
+
+        assert res.status_code == 200
+        res_json = res.json()
+        assert len(res_json["works"]) == 3
+        for work in res_json["works"]:
+            assert work.get("title") in [work1.title,work2.title,work3.title]

--- a/tests/test_work.py
+++ b/tests/test_work.py
@@ -650,7 +650,7 @@ class TestWork:
         )
         assert res.status_code == 200
         res_json = res.json()
-        assert len(res_json["works"]) == 3
+        assert len(res_json["works"]) == 2
 
         # hogeで検索
         res = client.get(


### PR DESCRIPTION
タグをID検索と名前検索に分けて実装。
任意の文字列を用いてユーザー名、タグ名、作品名に部分一致でデータ取得するように実装