### PR TITLE
fix: ブログのサムネイルが更新できない問題を修正

### DIFF
--- a/blogs/cruds/blogs/blogs.py
+++ b/blogs/cruds/blogs/blogs.py
@@ -315,6 +315,9 @@ def replace_blog(
             db.query(blog_models.BlogThumbnail).filter_by(blog_id=blog_id).first()
         )
         if thumbnail_orm.asset_id != thumbnail.id:
+            # 古いThumbnailを紐付け解除
+            db.delete(thumbnail_orm)
+            # 新しいThumbnailを紐付け
             new_thumbnail_orm = blog_models.BlogThumbnail(
                 blog_id=blog_id, asset_id=thumbnail.id
             )

--- a/blogs/cruds/blogs/blogs.py
+++ b/blogs/cruds/blogs/blogs.py
@@ -315,9 +315,7 @@ def replace_blog(
             db.query(blog_models.BlogThumbnail).filter_by(blog_id=blog_id).first()
         )
         if thumbnail_orm.asset_id != thumbnail.id:
-            # 古いThumbnailを紐付け解除
             db.delete(thumbnail_orm)
-            # 新しいThumbnailを紐付け
             new_thumbnail_orm = blog_models.BlogThumbnail(
                 blog_id=blog_id, asset_id=thumbnail.id
             )


### PR DESCRIPTION
ブログの更新時に古いサムネイルの紐付けを解除して、新しいサムネイルが正常に表示されるよう修正しました。

Closes #158 